### PR TITLE
refactor(base_model): 重构 base_enum 包的导入路径

### DIFF
--- a/base_model/base_enum/base_enum.go
+++ b/base_model/base_enum/base_enum.go
@@ -1,8 +1,8 @@
 package base_enum
 
 import (
-	"github.com/kysion/base-library/base_model/base_enum/internal/captcha"
-	"github.com/kysion/base-library/base_model/base_enum/internal/hook"
+	sys_enum_captcha "github.com/kysion/base-library/base_model/base_enum/internal/captcha"
+	sys_enum_hook "github.com/kysion/base-library/base_model/base_enum/internal/hook"
 )
 
 type (

--- a/utility/base_tree/base_tree_impl.go
+++ b/utility/base_tree/base_tree_impl.go
@@ -2,6 +2,8 @@ package base_tree
 
 // TestTree 结构实现了 Tree 接口，用于表示具有层次结构的树形数据。
 // 它包含节点信息、父节点ID、节点名称以及子节点列表。
+//
+//nolint:stylecheck
 type TestTree struct {
 	Id       int64       `json:"id"             dc:"ID" v:"integer"`                   // 节点ID，唯一标识一个节点。
 	ParentId int64       `json:"parentId"       dc:"父级ID" v:"min:0#必须是正整数"`            // 父节点ID，标识该节点的父节点。


### PR DESCRIPTION
- 更新了 base_enum 包中 captcha 和 hook 内部包的导入路径
- 在 base_tree 包中为 TestTree 结构体添加了 nolint 注释
